### PR TITLE
Fix workflows, remove AdGuard scripts, correct MIME type and og:url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Check that data is OK
       run: . ./.github/scripts/check-unique-guid.sh

--- a/.github/workflows/buildanddeployprod.yml
+++ b/.github/workflows/buildanddeployprod.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
 
     - name: Run the Transformer
       run: |

--- a/.github/workflows/buildanddeploystaging.yml
+++ b/.github/workflows/buildanddeploystaging.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
  
     - name: Run the Transformer
       run: |

--- a/.github/workflows/generate-offline.yml
+++ b/.github/workflows/generate-offline.yml
@@ -14,7 +14,7 @@ jobs:
   generateFile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       
       - name: Create output folder
         run: mkdir ./output

--- a/data/en/project/translation.json
+++ b/data/en/project/translation.json
@@ -1,7 +1,7 @@
 {
   "SITE_NAME": "The Azure Kubernetes Service Checklist",
   "INDEX_TITLE": "✨ Be ready for production ✨",
-  "URL_WEBSITE": "https://aka.ms/aks-checklist",
+  "URL_WEBSITE": "https://aka.ms/the-aks-checklist",
   "SITE_TAGLINE": "The AKS Checklist - the best way to ensure your cluster is production-ready!",
   "SITE_DESCRIPTION": "The AKS Checklist is a (tentatively) exhaustive list of all elements you need to think of when preparing a cluster for production. It's based on all common best practices agreed around Kubernetes. It is the best way to ensure your cluster is production-ready!",
   "SITE_VERSION":"Last updated on: ",

--- a/data/tooling/html-generator/template.html
+++ b/data/tooling/html-generator/template.html
@@ -32,7 +32,7 @@
     <meta name="msapplication-TileColor" content="#2b2b2b">
     <meta name="msapplication-TileImage" content="/icons/mstile-144x144.png">
     <meta property="og:site_name" content="The AKS Checklist - the best way to ensure your cluster is production-ready!">
-    <meta property="og:url" content="https://aka.ms/aks-checklist">
+    <meta property="og:url" content="https://aka.ms/the-aks-checklist">
     <meta property="og:type" content="website">
     <meta property="og:title" content="✨ Be ready for production ✨">
     <meta property="og:description" content="The AKS Checklist is a (tentatively) exhaustive list of all elements you need to think of when preparing a cluster for production. It's based on all common best practices agreed around Kubernetes. It is the best way to ensure your cluster is production-ready!">
@@ -76,7 +76,7 @@
                 <div class="s-header__banner">
                     <div class="text-center">
                         <picture>
-                            <source srcset="/img/logos/logo-aks-checklist.png" type="image/jpeg"><img class="img-logo" src="/img/logos/logo-aks-checklist.png" alt="AKS Checklist Logo" width="100" height="100"></picture>
+                            <source srcset="/img/logos/logo-aks-checklist.png" type="image/png"><img class="img-logo" src="/img/logos/logo-aks-checklist.png" alt="AKS Checklist Logo" width="100" height="100"></picture>
                         <h1 class="font-weight-bold">The Azure Kubernetes Service Checklist</h1>
                         <p class="sub-heading">This checklist contains a large set of best practices and some of them may not be relevant to your context and thus the rating may be incorrect in your case. Please choose and apply them wisely.</p>
                         <p class="sub-heading2">Last updated on: 

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -2,8 +2,6 @@
 <html class="no-js" lang="en" dir="ltr">
 
 <head>
-    <script type="text/javascript" nonce="450cebf84dcc4f6fb76976882bf" src="//local.adguard.org?ts=1751265097373&amp;type=content-script&amp;dmn=www.the-aks-checklist.com&amp;url=https%3A%2F%2Fwww.the-aks-checklist.com%2F&amp;app=firefox.exe&amp;css=3&amp;js=1&amp;rel=1&amp;rji=1&amp;sbe=1"></script>
-    <script type="text/javascript" nonce="450cebf84dcc4f6fb76976882bf" src="//local.adguard.org?ts=1751265097373&amp;name=AdGuard%20Extra&amp;name=AdGuard%20Popup%20Blocker&amp;type=user-script"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
@@ -34,7 +32,7 @@
     <meta name="msapplication-TileColor" content="#2b2b2b">
     <meta name="msapplication-TileImage" content="/icons/mstile-144x144.png">
     <meta property="og:site_name" content="The AKS Checklist - the best way to ensure your cluster is production-ready!">
-    <meta property="og:url" content="https://aka.ms/aks-checklist">
+    <meta property="og:url" content="https://aka.ms/the-aks-checklist">
     <meta property="og:type" content="website">
     <meta property="og:title" content="✨ Be ready for production ✨">
     <meta property="og:description" content="The AKS Checklist is a (tentatively) exhaustive list of all elements you need to think of when preparing a cluster for production. It's based on all common best practices agreed around Kubernetes. It is the best way to ensure your cluster is production-ready!">
@@ -78,7 +76,7 @@
                 <div class="s-header__banner">
                     <div class="text-center">
                         <picture>
-                            <source srcset="/img/logos/logo-aks-checklist.png" type="image/jpeg"><img class="img-logo" src="/img/logos/logo-aks-checklist.png" alt="AKS Checklist Logo" width="100" height="100"></picture>
+                            <source srcset="/img/logos/logo-aks-checklist.png" type="image/png"><img class="img-logo" src="/img/logos/logo-aks-checklist.png" alt="AKS Checklist Logo" width="100" height="100"></picture>
                         <h1 class="font-weight-bold">The Azure Kubernetes Service Checklist</h1>
                         <p class="sub-heading">This checklist contains a large set of best practices and some of them may not be relevant to your context and thus the rating may be incorrect in your case. Please choose and apply them wisely. <a class="blank-link" href="https://github.com/boxboat/aks-health-check"
                             target="_blank">You can also use the automated tool by BoxBoat</a></p>


### PR DESCRIPTION
## Summary

Small cleanup/fix PR addressing several issues spotted during a repo review.

### Changes
- **CI workflows**: bump `actions/checkout` from `v5` to `v7` in all four workflows (`build.yml`, `buildanddeployprod.yml`, `buildanddeploystaging.yml`, `generate-offline.yml`).
- **AdGuard cleanup**: remove two `//local.adguard.org` `<script>` tags accidentally committed into `src/web/index.html` (injected by a browser extension — junk that shouldn't ship).
- **MIME type fix** (point 9): the `<picture><source>` for the PNG logo declared `type="image/jpeg"`; corrected to `image/png` in both `index.html` and the generator `template.html`.
- **og:url fix** (point 12): corrected `og:url` / `URL_WEBSITE` from `https://aka.ms/aks-checklist` to the canonical `https://aka.ms/the-aks-checklist` in `index.html`, `template.html` and `translation.json`.

Both the generated `src/web/index.html` and the source `template.html` were updated so they stay in sync.