### PR TITLE
Fix duplicate GUID, global GUID validation, dynamic priority counts, precache path

### DIFF
--- a/.github/scripts/check-unique-guid.sh
+++ b/.github/scripts/check-unique-guid.sh
@@ -51,6 +51,27 @@ do
   echo ''
 done
 
+# Global uniqueness check across ALL files (the per-file loop above only
+# detects duplicates within a single file, not across different files)
+echo -e "\e[4mGLOBAL UNIQUENESS CHECK (across all files)\e[0m"
+
+global_guids=$(jq -r "try .. | objects | select( .$key_name ) | .$key_name" *.json)
+global_total=$(printf '%s\n' "$global_guids" | wc -l)
+global_unique=$(printf '%s\n' "$global_guids" | sort -u | wc -l)
+
+if [ "$global_total" -ne "$global_unique" ]; then
+  echo -e "\e[0;31mERROR\e[0m: $global_total GUIDs found across all files, but only $global_unique are unique"
+  echo "Here are the duplicates:"
+  printf '%s\n' "$global_guids" | sort | uniq -d
+  globalError=1
+  echo -e " \e[0;31mKO\e[0m All tests are not green"
+else
+  echo "All GUIDs are unique across all files"
+  echo -e " \e[0;32mOK\e[0m All tests are green"
+fi
+
+echo ''
+
 # If there was an error, exit to fail the build
 if [[ "$globalError" == 1 ]]; then
     exit 1

--- a/data/en/items/operations.json
+++ b/data/en/items/operations.json
@@ -510,7 +510,7 @@
   {
     "title": "Consider an appropriate node size, not too large or too small",
     "priority": "High",
-    "guid": "5ae124ba-34df-4585-bcdc-e9bd3bb0cdb3",
+    "guid": "495e0503-5fbd-4ba7-8c33-2551b1676d1e",
     "description": "Optimizing node size can lead to lots of benefits including cost optimization, optimized performance and proper resource allocation",
     "documentation": [
       {

--- a/data/tooling/html-generator/template.html
+++ b/data/tooling/html-generator/template.html
@@ -213,15 +213,15 @@
                             <li class="c-notation__details__item js-detail-high">
                                 <svg class="icon icon--small icon-priority--high" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 510 510" aria-hidden="true" data-icon-name="bullet">
                                     <path d="M255 0C114.75 0 0 114.75 0 255s114.75 255 255 255 255-114.75 255-255S395.25 0 255 0z"></path>
-                                </svg><span class="js-notation-checked">0</span>/<span class="js-notation-total">51</span>&nbsp;✓ high priority</li>
+                                </svg><span class="js-notation-checked">0</span>/<span class="js-notation-total">%COUNT_HIGH%</span>&nbsp;✓ high priority</li>
                             <li class="c-notation__details__item js-detail-medium">
                                 <svg class="icon icon--small icon-priority--medium" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 510 510" aria-hidden="true" data-icon-name="bullet">
                                     <path d="M255 0C114.75 0 0 114.75 0 255s114.75 255 255 255 255-114.75 255-255S395.25 0 255 0z"></path>
-                                </svg><span class="js-notation-checked">0</span>/<span class="js-notation-total">72</span>&nbsp;✓ medium priority</li>
+                                </svg><span class="js-notation-checked">0</span>/<span class="js-notation-total">%COUNT_MEDIUM%</span>&nbsp;✓ medium priority</li>
                             <li class="c-notation__details__item js-detail-low">
                                 <svg class="icon icon--small icon-priority--low" xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 510 510" aria-hidden="true" data-icon-name="bullet">
                                     <path d="M255 0C114.75 0 0 114.75 0 255s114.75 255 255 255 255-114.75 255-255S395.25 0 255 0z"></path>
-                                </svg><span class="js-notation-checked">0</span>/<span class="js-notation-total">44</span>&nbsp;✓ low priority</li>
+                                </svg><span class="js-notation-checked">0</span>/<span class="js-notation-total">%COUNT_LOW%</span>&nbsp;✓ low priority</li>
                         </ul>
                     </div>
                     <div class="c-notation__box">

--- a/src/generator/Generator.cs
+++ b/src/generator/Generator.cs
@@ -8,6 +8,10 @@ namespace aks_generator
     {
         private int _sectionId = 0;
 
+        public int HighCount { get; private set; }
+        public int MediumCount { get; private set; }
+        public int LowCount { get; private set; }
+
         public string ParseCategory(string category, string path, string fileName)
         {
             // parse a json file and return a list of CheckListItems
@@ -105,6 +109,13 @@ namespace aks_generator
             // Convertir la priorité en format CSS
             string priorityClass = item.Priority.ToLowerInvariant();
             string priorityText = item.Priority;
+
+            switch (priorityClass)
+            {
+                case "high": HighCount++; break;
+                case "medium": MediumCount++; break;
+                case "low": LowCount++; break;
+            }
 
             // Convertir le nom de section en format kebab-case
             string sectionSlug = identifier;

--- a/src/generator/Program.cs
+++ b/src/generator/Program.cs
@@ -52,6 +52,9 @@ if (string.IsNullOrEmpty(options.OutputFile))
 string fileContent = File.ReadAllText(options.FilePath);
 fileContent = fileContent.Replace("%DATE%", dateToInject);
 fileContent = fileContent.Replace("%CONTENT%", textToInject);
+fileContent = fileContent.Replace("%COUNT_HIGH%", Generator.HighCount.ToString());
+fileContent = fileContent.Replace("%COUNT_MEDIUM%", Generator.MediumCount.ToString());
+fileContent = fileContent.Replace("%COUNT_LOW%", Generator.LowCount.ToString());
 
 // write content back to file
 File.WriteAllText(options.OutputFile, fileContent);

--- a/src/web/precache-config.js
+++ b/src/web/precache-config.js
@@ -1,7 +1,7 @@
 module.exports = {
   staticFileGlobs: [
     'index.html',
-    'mstile-144x144.png',
+    'mstile-150x150.png',
     'browserconfig.xml'
   ],
   navigateFallback: '/index.html',


### PR DESCRIPTION
Second batch of review fixes (data + build), independent from #327/#328.

### A — Duplicate GUID across files
The GUID `5ae124ba-34df-4585-bcdc-e9bd3bb0cdb3` was shared by two different items:
- `cluster_security.json` → *If required consider using Azure Dedicated Hosts…*
- `operations.json` → *Consider an appropriate node size…*

Assigned a fresh unique GUID to the `operations.json` item.

### B — GUID check missed cross-file duplicates
`check-unique-guid.sh` only validated uniqueness **within each file** (`for file in *.json`), so the duplicate in A went undetected. Added a global cross-file uniqueness check that fails the build if any GUID is reused across files.

### C — Hardcoded (and stale) priority counts
`template.html` hardcoded `high 51 / medium 72 / low 44`; the real data is **52 / 72 / 44**, so `high` was already wrong and would keep drifting. The generator now counts high/medium/low items and injects them via `%COUNT_HIGH%` / `%COUNT_MEDIUM%` / `%COUNT_LOW%` placeholders.

### D — Precache references a missing file
`precache-config.js` listed `mstile-144x144.png` (doesn't exist); pointed it to the existing `mstile-150x150.png`.

> Note: the C# generator and the bash script were not run locally (no .NET SDK / jq / bash in my environment); `index.html` is regenerated from `template.html` by CI on build.